### PR TITLE
Use grunt-cli that's local to project

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "grunt": "^0.4.5",
     "grunt-assemble": "^0.4.0",
     "grunt-autoprefixer": "^3.0.3",
+    "grunt-cli": "^1.2.0",
     "grunt-contrib-copy": "^1.0.0",
     "grunt-contrib-jshint": "^1.0.0",
     "grunt-contrib-watch": "^1.0.0",


### PR DESCRIPTION
*First off, thanks for providing such an amazing service and this wonderful tool! Our day-to-day would be very tough without both :-)*

---

With `grunt-cli` versions 0.4+, it's [recommended NOT to install Grunt globally](https://github.com/gruntjs/grunt-cli#grunt-cli--). I think it's a good idea because instead of an additional step to get started, one can just pull down, `npm install` and `npm start` right away. The Wiki would needed to be updated to reflect this.

**The technical details:**
NPM scripts automatically get `./node_modules/.bin` added to the `$PATH` to which it looks for binaries to run. Since `grunt-cli` [exposes a `bin` propery](https://github.com/gruntjs/grunt-cli/blob/master/package.json#L14-L16), it can be leveraged this way.

Let me know what you guys think!