### PR TITLE
Make secrets.json optional

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -30,7 +30,7 @@ module.exports = function(grunt) {
        common changes centralized to key files instead of being littered
        throughout the Gruntfile. This also makes it easy to .gitignore secrets
     ================================================= */
-    secret: grunt.file.readJSON('secrets.json'),
+    secret: grunt.file.exists('secrets.json') ? grunt.file.readJSON('secrets.json') : {},
     config: grunt.file.readJSON('config.json'),
 
     /* SASS


### PR DESCRIPTION
Related to issue #23.

I think that if someone doesn't want secrets.json, they shouldn't be required to create it. 

This PR just checks if secrets.json exists before trying to load it. Otherwise, it inserts an empty object so no errors are thrown.
