### PR TITLE
Added more hiding to preheader for Outlook 2016

### DIFF
--- a/src/stylesheets/scss/_layout.scss
+++ b/src/stylesheets/scss/_layout.scss
@@ -68,10 +68,9 @@
   visibility: hidden;
   mso-hide: all;
   font-size: 1px;
-  color: #ffffff;
   line-height: 1px;
-  max-height: 0px;
-  max-width: 0px;
+  max-height: 0;
+  max-width: 0;
   opacity: 0;
   overflow: hidden;
 }

--- a/src/stylesheets/scss/_layout.scss
+++ b/src/stylesheets/scss/_layout.scss
@@ -65,6 +65,15 @@
 }
 .preheader {
   display: none !important;
+  visibility: hidden;
+  mso-hide: all;
+  font-size: 1px;
+  color: #ffffff;
+  line-height: 1px;
+  max-height: 0px;
+  max-width: 0px;
+  opacity: 0;
+  overflow: hidden;
 }
 
 /* Attribute list ------------------------------ */


### PR DESCRIPTION
Currently the templates render the preheader section when shown in Microsoft Outlook 2016 on Windows. Added some more CSS hiding magic to ensure it's never shown in the mail message but is still used on the item preview.