### PR TITLE
Fixed variable name typo in comment_notification template

### DIFF
--- a/dist/comment_notification.html
+++ b/dist/comment_notification.html
@@ -400,7 +400,7 @@
                             <table width="100%" cellpadding="0" cellspacing="0">
                               {{#each . }}
                               <tr>
-                                <td class="attributes_item"><a href="{{attachmnet_url}}">{{attachment_name}}</a> <span>({{attachment_size}} {{attachment_type}})</span></td>
+                                <td class="attributes_item"><a href="{{attachment_url}}">{{attachment_name}}</a> <span>({{attachment_size}} {{attachment_type}})</span></td>
                               </tr>
                               {{/each}}
                             </table>

--- a/dist/comment_notification.txt
+++ b/dist/comment_notification.txt
@@ -4,7 +4,7 @@
 
 {{#each . }}
 
-{{attachment_name}} ( {{ attachmnet_url }} ) ({{attachment_size}} {{attachment_type}})
+{{attachment_name}} ( {{ attachment_url }} ) ({{attachment_size}} {{attachment_type}})
 
 {{/each}}
 

--- a/src/emails/comment_notification.hbs
+++ b/src/emails/comment_notification.hbs
@@ -1,7 +1,7 @@
 ---
 layout: layout.hbs
 subject: "{{commenter_name}} made a comment"
-preheader: 
+preheader:
 ---
 <table class="email-content" width="100%" cellpadding="0" cellspacing="0">
 
@@ -23,7 +23,7 @@ preheader:
                   <table width="100%" cellpadding="0" cellspacing="0">
                     \{{#each . }}
                     <tr>
-                      <td class="attributes_item"><a href="\{{attachmnet_url}}">\{{attachment_name}}</a> <span>(\{{attachment_size}} \{{attachment_type}})</span></td>
+                      <td class="attributes_item"><a href="\{{attachment_url}}">\{{attachment_name}}</a> <span>(\{{attachment_size}} \{{attachment_type}})</span></td>
                     </tr>
                     \{{/each}}
                   </table>
@@ -47,5 +47,3 @@ preheader:
     </td>
   </tr>
 </table>
-
-


### PR DESCRIPTION
Just fixing up a typo in the comment notification template.

`attachmnet_url` should be `attachment_url`.