### PR TITLE
fix template deployment when using powershell

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -365,10 +365,15 @@ module.exports = function(grunt) {
     shell: {
       options: {
         stderr: true,
+        execOptions: {
+          env: {
+            'POSTMARK_SERVER_TOKEN': '<%= secret.postmark.server_token %>'
+          }
+        }
       },
       postmarkPush: {
         command:
-          'POSTMARK_SERVER_TOKEN=<%= secret.postmark.server_token %> postmark templates push ./dist',
+          'postmark templates push ./dist',
       },
     },
 


### PR DESCRIPTION
I noticed that `npm deploy` would error out when I ran it from VS Code which (at least in my setup) uses powershell.

This pull request defines the `POSTMARK_SERVER_TOKEN` environment variable in `execOptions.env` (see https://github.com/sindresorhus/grunt-shell#execoptions) instead of setting it on the command line which works on powershell and should presumably also work in other shells. I have however only tested it on windows using both powershell and cmd.