### PR TITLE
Adds access & destination config options for grunt-aws 

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -1,4 +1,4 @@
-module.exports = function(grunt) {
+module.exports = function (grunt) {
   const sass = require('node-sass')
   require('load-grunt-tasks')(grunt, { pattern: ['grunt-*', 'assemble'] })
   require('time-grunt')(grunt)
@@ -224,11 +224,12 @@ module.exports = function(grunt) {
         secretAccessKey: '<%= secret.s3.secret_access_key %>',
         bucket: '<%= config.s3.bucket %>',
         region: '<%= config.s3.region %>',
-        overwrite: '<%= config.s3.overwrite %>',
+        access: '<%= config.s3.access %>'
       },
       build: {
         cwd: path.images_src,
         src: '**',
+        dest: "<%= config.s3.dest %>"
       },
     },
 

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -224,6 +224,7 @@ module.exports = function (grunt) {
         secretAccessKey: '<%= secret.s3.secret_access_key %>',
         bucket: '<%= config.s3.bucket %>',
         region: '<%= config.s3.region %>',
+        overwrite: '<%= config.s3.overwrite %>',
         access: '<%= config.s3.access %>'
       },
       build: {

--- a/example_config.json
+++ b/example_config.json
@@ -42,6 +42,8 @@
   "s3": {
     "bucket": "",
     "region": "",
+    "dest": "/",
+    "access": "private",
     "overwrite": true
   }
 }

--- a/example_config.json
+++ b/example_config.json
@@ -43,7 +43,7 @@
     "bucket": "",
     "region": "",
     "dest": "/",
-    "access": "private",
+    "access": "public-read",
     "overwrite": true
   }
 }


### PR DESCRIPTION
1. While setting up s3 I was getting Access Denied errors which were solved by passing an Access permission option.

`access` (String)
Default "public-read"

File permissions, must be one of:
```
"private"
"public-read"
"public-read-write"
"authenticated-read"
"bucket-owner-read"
"bucket-owner-full-control"
```

2. Once passing the correct access permission (in my case `private`) the upload worked! However a new problem arose; They were getting dumped into root. 

grunt-aws has a `dest` (String) option which allows you to specify where to upload the files. By including this option my use case/set up was complete.

```
      build: {
        cwd: path.images_src,
        src: '**',
        dest: "<%= config.s3.dest %>"
      }
```

3. Another potential "Fix" would simply add these edge cases to the Wiki however I think them common enough for them tp be in the example/default configs.

